### PR TITLE
Fix create instructions so they include custom base if set

### DIFF
--- a/create.py
+++ b/create.py
@@ -82,6 +82,9 @@ def default(base=None):
     print("Created %s" % config)
     print("Modify this file with your own settings, and then run:")
     print("")
-    print("    %s start" % sys.argv[0])
+    if base:
+        print("    %s start %s" % (sys.argv[0], base))
+    else:
+        print("    %s start" % sys.argv[0])
 
     return True


### PR DESCRIPTION
If you specify a custom base directory, the instructions given are wrong. This fixes that problem by including the custom base directory in the output instructions for how to subsequently run saxo. 
