### PR TITLE
Silently create configuration subdirs

### DIFF
--- a/common.py
+++ b/common.py
@@ -69,9 +69,13 @@ def exit_cleanly():
 def populate(saxo_path, base):
     plugins = os.path.join(base, "plugins")
     saxo_plugins = os.path.join(saxo_path, "plugins")
+    if not os.path.isdir(plugins):
+        os.mkdir(plugins)
 
     commands = os.path.join(base, "commands")
     saxo_commands = os.path.join(saxo_path, "commands")
+    if not os.path.isdir(commands):
+        os.mkdir(commands)
 
     def symlink(source, dest):
         try: os.symlink(source, dest)

--- a/irc.py
+++ b/irc.py
@@ -549,10 +549,9 @@ def serve(sockname, incoming):
             common.thread(handle, connection, client)
     common.thread(listen, sock)
 
-E_NO_PLUGINS = """
-The plugins directory is necessary for saxo to work. If it was deleted
-accidentally, just make a new empty directory and saxo will automatically
-populate it with the core plugin that it needs to work.
+E_NO_CONFIG = """
+Are you sure this is a saxo configuration directory? If you need to make a new
+configuration directory, use the saxo `create` command.
 """
 
 def start(base):
@@ -562,17 +561,15 @@ def start(base):
     # IGN rather than DFL, otherwise Popen.communicate can quit saxo
     signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 
-    plugins = os.path.join(base, "plugins")
-    if not os.path.isdir(plugins):
-        common.error("no plugins directory: `%s`" % plugins, E_NO_PLUGINS)
-
-    common.populate(saxo_path, base)
-
     opt = configparser.ConfigParser(interpolation=None)
     config = os.path.join(base, "config")
+    if not os.path.isfile(config):
+        error("missing config file in: `%s`" % config, E_NO_CONFIG)
     opt.read(config)
     # TODO: Defaulting?
     # TODO: Warn if the config file is widely readable?
+
+    common.populate(saxo_path, base)
 
     sockname =  os.path.join(base, "client.sock")
     serve(sockname, incoming)


### PR DESCRIPTION
I want to keep my configuration directory in Git, but I don't want to commit symlinks, and Git doesn't handle empty directories very well. This patch does a quick check for the `config` file in the configuration directory. If it exists, the `commands` and `plugins` directories will be created silently and populated if they are missing.
