### PR TITLE
Handle relative command file symlinks

### DIFF
--- a/common.py
+++ b/common.py
@@ -96,6 +96,7 @@ def populate(saxo_path, base):
                 continue
 
             target = os.readlink(link)
+            target = os.path.join(directory, target)
             if not os.path.exists(target):
                 os.remove(link)
 


### PR DESCRIPTION
Right now, `saxo` will remove any relative symlinks you may have added to the `commands` directory. This patch resolves relative symlinks against the parent directory.
