### PR TITLE
Add support for identify-msg

### DIFF
--- a/docs/write-commands.md
+++ b/docs/write-commands.md
@@ -206,9 +206,12 @@ Here are some environment variables you can use:
 * `SAXO_BASE` — the path of the base directory that saxo is using
 * `SAXO_COMMANDS` — the path of the commands directory. equivalent to `$SAXO_BASE/commands`
 * `SAXO_NICK` — the nickname of the user issuing the command
+* `SAXO_IDENTIFIED` — whether the user is identified with the network
 * `SAXO_SENDER` — the channel where the command was issued
 * `SAXO_BOT` — the nickname that saxo is using itself
 * `SAXO_URL` — the most recently mentioned URL in the channel where the command was issued
+
+The `SAXO_IDENTIFIED` environment variable is only present when the host IRC network supports this feature.
 
 These environment variables are only available when a command is run by the bot. If you are writing a command that also functions as a CLI script, you must check for the presence of an environment variable before using it.
 

--- a/plugins/core.py
+++ b/plugins/core.py
@@ -15,6 +15,7 @@ def first(irc):
     for channel in irc.config["channels"].split(" "):
         irc.send("JOIN", channel)
     irc.send("WHO", irc.config["nick"])
+    irc.send("CAP REQ", "identify-msg")
 
 @saxo.event("352")
 def who(irc):
@@ -27,3 +28,12 @@ def who(irc):
 @saxo.event("PING")
 def ping(irc):
     irc.send("PONG", irc.config["nick"])
+
+@saxo.event("CAP")
+def cap(irc):
+    if irc.parameters[0] != irc.config["nick"]:
+        return
+    if irc.parameters[1] != "ACK":
+        return
+    if "identify-msg" in irc.parameters[2].split():
+        irc.client("identify_msg", True)


### PR DESCRIPTION
Some IRC networks support the `identify-msg` capability. This prepends all `PRIVMSG` messages with a `+` or  `-` character to indicate whether the user is identified with network services or not.

This patch requests the capability from the network, and if present, parses these characters, and passes the status through to commands via the `SAXO_IDENTIFIED` environment variable.

I have verified that this works with commands. But have not verified that it works for plugins. Though, I added an additional class property on the `ThreadSafeEnvironment` class as requested.
