### PR TITLE
Fix Travis CI notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,7 @@ python:
   - "3.3"
 script: python saxo test
 notifications:
-  irc: "chat.freenode.net#swhack"
+  irc:
+    channels:
+      "chat.freenode.net#swhack"
+    on_success: change


### PR DESCRIPTION
The default setting for IRC notifications is to notify on every successful build.

This patch changes that so that a success is only notified when it changes from a failure.
