### PR TITLE
Fix Travis CI IRC behaviour

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,3 +7,4 @@ notifications:
     channels:
       "chat.freenode.net#swhack"
     on_success: change
+    skip_join: true


### PR DESCRIPTION
At the moment, the IRC bot joins the channel each time, which is noisy.

This patch fixes that.
