### PR TITLE
Changed btc command to use bitcoinaverage.com instead of mtgox.com

### DIFF
--- a/commands/btc
+++ b/commands/btc
@@ -10,7 +10,7 @@ import saxo
 def btc(arg):
     if arg:
         return "This command takes no argment"
-    url = "http://data.mtgox.com/api/2/BTCUSD/money/ticker_fast"
+    url = "https://api.bitcoinaverage.com/ticker/global/all"
     page = saxo.request(url)
     data = json.loads(page["text"])
-    return data["data"]["sell"]["value"][:6] + " USD (mtgox)"
+    return str(data["USD"]["last"]) + " USD (BitcoinAverage)"


### PR DESCRIPTION
Mt. Gox is dead, and bitcoinaverage.com is a respected independent indicator of price as it uses the average across multiple exchanges.
