### PR TITLE
Typo fix: argment -> argument

### DIFF
--- a/commands/btc
+++ b/commands/btc
@@ -9,7 +9,7 @@ import saxo
 @saxo.pipe
 def btc(arg):
     if arg:
-        return "This command takes no argment"
+        return "This command takes no argument"
     url = "https://api.bitcoinaverage.com/ticker/global/all"
     page = saxo.request(url)
     data = json.loads(page["text"])


### PR DESCRIPTION
`<melbel> maybe it meant argmint? tasty tasty`
