### PR TITLE
Make the connection step more IRCd cross-compatible

### DIFF
--- a/plugins/core.py
+++ b/plugins/core.py
@@ -12,6 +12,9 @@ def connected(irc):
 def first(irc):
     irc.send("NICK", irc.config["nick"])
     irc.send("USER", irc.config["nick"], "+iw", irc.config["nick"], "saxo")
+
+@saxo.event("001")
+def welcomed(irc):
     for channel in irc.config["channels"].split(" "):
         irc.send("JOIN", channel)
     irc.send("WHO", irc.config["nick"])
@@ -26,4 +29,4 @@ def who(irc):
 
 @saxo.event("PING")
 def ping(irc):
-    irc.send("PONG", irc.config["nick"])
+    irc.send("PONG", irc.parameters[0])


### PR DESCRIPTION
Some popular IRCds, such as charybdis, will send you a 451 "not registered" error if you send a JOIN or WHO command before responding to the initial PING request the server sends you, hence saxo fails to connect. This change makes it so that saxo only sends those commands after receiving the RPL_WELCOME message (001), as specified in [RFC 2812](http://www.networksorcery.com/enp/rfc/rfc2812.txt).

Some popular IRCds, such as charybdis, also only accept PONG replies that match the PING argument sent by the server. This commit makes it so that saxo respects that.
