### PR TITLE
Travis CI: Lint Python code for syntax errors and undefined names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: python
 python:
-  - "3.5"
-  - "3.7"
+  - "3.6"
+  - "3.8"
 script:
   - python saxo -v
   - python saxo test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
   - "3.5"
   - "3.7"
 script:
+  - python saxo -v
   - python saxo test
   - pip install flake8
   - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 language: python
 python:
-  - "3.3"
-script: python saxo test
+  - "3.5"
+  - "3.7"
+script:
+  - python saxo test
+  - pip install flake8
+  - flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 notifications:
   irc:
     channels:

--- a/core.py
+++ b/core.py
@@ -37,6 +37,7 @@ if "__file__" in vars():
 if "__path__" in vars():
     global __path__
     if __path__:
+        global __path__
         for directory in __path__:
             if path is None:
                 path = directory

--- a/core.py
+++ b/core.py
@@ -35,6 +35,7 @@ if "__file__" in vars():
         path = os.path.dirname(path)
 
 if "__path__" in vars():
+    global __path__
     if __path__:
         for directory in __path__:
             if path is None:

--- a/core.py
+++ b/core.py
@@ -34,15 +34,15 @@ if "__file__" in vars():
         path = os.path.realpath(path)
         path = os.path.dirname(path)
 
-if "__path__" in vars():
-    global __path__
+try:
     if __path__:
-        global __path__
         for directory in __path__:
             if path is None:
                 path = directory
             elif path != directory:
                 raise Exception("Can't create saxo.path")
+except NameError:
+    pass
 
 if path is None:
    raise Exception("Can't create saxo.path")

--- a/irc.py
+++ b/irc.py
@@ -821,7 +821,7 @@ def start(base):
     opt = configparser.ConfigParser(interpolation=None)
     config = os.path.join(base, "config")
     if not os.path.isfile(config):
-        Error("missing config file in: `%s`" % config, E_NO_CONFIG)
+        Exception("missing config file in: `%s`" % config, E_NO_CONFIG)
     opt.read(config)
     # TODO: Defaulting?
     # TODO: Warn if the config file is widely readable?

--- a/irc.py
+++ b/irc.py
@@ -821,7 +821,7 @@ def start(base):
     opt = configparser.ConfigParser(interpolation=None)
     config = os.path.join(base, "config")
     if not os.path.isfile(config):
-        error("missing config file in: `%s`" % config, E_NO_CONFIG)
+        Error("missing config file in: `%s`" % config, E_NO_CONFIG)
     opt.read(config)
     # TODO: Defaulting?
     # TODO: Warn if the config file is widely readable?


### PR DESCRIPTION
Output: https://travis-ci.com/cclauss/saxo

Travis CI will no longer run tests on Python 3.3 because it is EOL.
https://devguide.python.org/devcycle/#end-of-life-branches